### PR TITLE
minor cleanups, missing Tooltip-texts

### DIFF
--- a/src/app/language-selector/language-selector.component.html
+++ b/src/app/language-selector/language-selector.component.html
@@ -1,6 +1,9 @@
-<mat-select #langSelect (valueChange)="onChangeLang($event)" [(value)]="currentLang">
+<mat-select (valueChange)="onChangeLang($event)" [(value)]="currentLang">
+  <mat-select-trigger>
+    <mat-icon [svgIcon]="currentLang"></mat-icon>
+    {{ currentLang }}
+  </mat-select-trigger>
   <mat-option *ngFor="let lang of supportedLanguages" [value]="lang" >
     <mat-icon [svgIcon]="lang"></mat-icon> {{ lang }}
   </mat-option>
 </mat-select>
-<mat-icon matSuffix [svgIcon]="currentLang"></mat-icon>

--- a/src/app/yearly-consumption-calculator/yearly-consumption-calculator.component.html
+++ b/src/app/yearly-consumption-calculator/yearly-consumption-calculator.component.html
@@ -14,7 +14,10 @@
     </mat-form-field>
     <mat-form-field class="example-full-width" appearance="outline">
       <mat-label>{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.LABEL' | translate }}</mat-label>
-      <input matInput placeholder="{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.PLACEHOLDER' | translate }}" type="number" id="wattsPerDay" formControlName="wattsPerDay">
+      <input matInput
+             placeholder="{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.PLACEHOLDER' | translate }}"
+             type="number" id="wattsPerDay" formControlName="wattsPerDay"
+             title="{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.TITLE' | translate }}">
       <span matTextSuffix>{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.SUFFIX' | translate }}</span>
       <mat-error *ngIf="wattsPerDayControl?.hasError('required')">{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.VALIDATION-ERROR.REQUIRED' | translate }}</mat-error>
       <mat-error *ngIf="wattsPerDayControl?.hasError('min')">{{ 'YEARLY-CONSUMPTION.FORM.NUMBER_OF_DAYS.CONSUMPTION_PER_DAY.VALIDATION-ERROR.MIN' | translate }}</mat-error>

--- a/src/app/yearly-costs-calculator/yearly-costs-calculator.component.html
+++ b/src/app/yearly-costs-calculator/yearly-costs-calculator.component.html
@@ -28,8 +28,10 @@
 
     <mat-form-field class="example-full-width" appearance="outline">
       <mat-label>{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.LABEL' | translate }}</mat-label>
-      <input matInput placeholder="{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.PLACEHOLDER' | translate }}" type="number" id="electricityPrice" formControlName="electricityPrice"
-             title="{{ 'YEARLY_COSTS.FORM.STANDBY_HOURS_PER_DAY.ELECTRICITY_PRICE.TITLE' | translate }}">
+      <input matInput placeholder="{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.PLACEHOLDER' | translate }}"
+             type="number" id="electricityPrice"
+             formControlName="electricityPrice"
+             title="{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.TITLE' | translate }}">
       <span matTextSuffix>{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.SUFFIX' | translate }}</span>
       <mat-error *ngIf="electricityPriceControl?.hasError('required')">{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.VALIDATION-ERROR.REQUIRED' | translate }}</mat-error>
       <mat-error *ngIf="electricityPriceControl?.hasError('min')">{{ 'YEARLY_COSTS.FORM.ELECTRICITY_PRICE.VALIDATION-ERROR.MIN' | translate }}</mat-error>

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -6,7 +6,7 @@
       "NUMBER_OF_DAYS": {
         "LABEL": "Anzahl der Tage:",
         "PLACEHOLDER": "z.B. '365'",
-        "TITLE": "Geben Sie die Anzahl der Tage pro Jahr ein",
+        "TITLE": "Geben Sie die Anzahl der Tage pro Jahr ein an denen das Gerät Energie verbraucht",
         "SUFFIX": "Tage / Jahr",
         "VALIDATION-ERROR": {
           "REQUIRED": "Die Anzahl der Tage ist erforderlich",
@@ -16,6 +16,7 @@
         "CONSUMPTION_PER_DAY": {
           "LABEL": "Verbrauch pro Tag:",
           "PLACEHOLDER": "z.B. '12'",
+          "TITLE": "Geben sie den durchschnittlichen täglichen Energieverbrauch des Gerätes ein",
           "SUFFIX": "kWh / Tag",
           "VALIDATION-ERROR": {
             "REQUIRED": "Verbrauch pro Tag ist erforderlich",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,7 +6,7 @@
       "NUMBER_OF_DAYS": {
         "LABEL": "Number of days:",
         "PLACEHOLDER": "e.g. '365'",
-        "TITLE": "Enter the number of days per year",
+        "TITLE": "Enter the number of days per year on which the appliance consumes energy",
         "SUFFIX": "days / year",
         "VALIDATION-ERROR": {
           "REQUIRED": "Number of days is required",
@@ -16,6 +16,7 @@
         "CONSUMPTION_PER_DAY": {
           "LABEL": "Consumption per Day:",
           "PLACEHOLDER": "e.g. '12'",
+          "TITLE": "Enter the device's average daily energy consumption",
           "SUFFIX": "kWh / day",
           "VALIDATION-ERROR": {
             "REQUIRED": "Consumption per Day is required",


### PR DESCRIPTION
* added missing Tooltip (attribute "Title") texts to all form input-fields

language-selector.component.html
* cleanup
* now using mat-select-trigger to render the currently selected option, in order to get the flag-icon in the same line as the language-text

yearly-consumption-calculator.component.html
* re-formatted file
* added Tooltip-text to numberOfDays-input
* added Tooltip-text to wattsPerDay-input

yearly-costs-calculator.component.html
* fixed wrong key for electricity-price Tooltip ('YEARLY_COSTS.FORM.ELECTRICITY_PRICE.PLACEHOLDER')